### PR TITLE
Fileglob Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: python
 
 # support minimum python versions specified here:
 # https://docs.ansible.com/ansible/dev_guide/developing_modules_python3.html
-python:
-  - "2.6"
-  - "3.5"
+python: 2.7
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ language: python
 # support minimum python versions specified here:
 # https://docs.ansible.com/ansible/dev_guide/developing_modules_python3.html
 python:
-  - 2.7
-  - 3.5
+  - "2.6"
+  - "3.5"
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: python
 
 # support minimum python versions specified here:
 # https://docs.ansible.com/ansible/dev_guide/developing_modules_python3.html
-python: 2.7
+python:
+  - 2.7
+  - 3.5
 
 cache:
   pip: true

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Run Goss with a specific version:
 ```
  - hosts: servers
    roles:
-     - { role: degoss, version: "0.2.5", tests: goss.yml }
+     - { role: degoss, version: "0.2.5", tests: ["goss.yml"] }
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Role Variables
 
 <dl>
   <dt><code>tests</code></dt>
-  <dd>A Goss test file or list of files to run on the target machine.</dd>
+  <dd>A Goss test file or list of files to run on the target machine. These test files should be listed in an array like in the example playbook below.</dd>
   <dt><code>version</code></dt>
   <dd>The version string of Goss to install. Example: <code>0.2.5</code>.</dd>
 </dl>
@@ -35,7 +35,7 @@ Run Goss:
 ```
  - hosts: servers
    roles:
-     - { role: degoss, tests: goss.yml }
+     - { role: degoss, tests: ["goss.yml", "goss2.yml"] }
 ```
 
 Run Goss with a specific version:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # defaults file for degoss
 version: latest
-tests: goss.yml
+tests: ["goss.yml"]
 format: rspecish

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,0 @@
----
-# handlers file for degoss
- - name: clean
-   file: path=/tmp/degoss state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,6 @@
      - /tmp/degoss
      - /tmp/degoss/bin
      - /tmp/degoss/tests
-   notify: clean
 
  # download goss
  - name: install
@@ -63,3 +62,6 @@
  - name: run tests
    goss: executable=/tmp/degoss/bin/goss path="/tmp/degoss/tests/{{ item }}" format="{{ format }}"
    with_items: "{{ test_files }}"
+
+ - name: clean
+   file: path=/tmp/degoss state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,21 @@
    copy: src={{ item }} dest=/tmp/degoss/tests/
    with_items: "{{ tests }}"
 
+ - name: define tests
+   set_fact:
+    test_files: |
+      {% set test_list = [] -%}
+      {%- for test in tests -%}
+        {%- if '/' in test -%}
+          {% set ignored = test_list.append(test.split('/') | last) -%}
+        {%- else -%}
+          {% set ignored = test_list.append(test) -%}
+        {%- endif -%}
+      {%- endfor %}
+      {{ test_list }}
+
+
  # run the tests
  - name: run tests
-   goss: executable=/tmp/degoss/bin/goss path="{{ item }}" format="{{ format }}"
-   with_fileglob: /tmp/degoss/tests/*.yml
+   goss: executable=/tmp/degoss/bin/goss path="/tmp/degoss/tests/{{ item }}" format="{{ format }}"
+   with_items: "{{ test_files }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,6 +44,7 @@
    copy: src={{ item }} dest=/tmp/degoss/tests/
    with_items: "{{ tests }}"
 
+ # identify names of files to test
  - name: define tests
    set_fact:
     test_files: |

--- a/tests/test-failure.yml
+++ b/tests/test-failure.yml
@@ -6,4 +6,5 @@
   roles:
     # since this is the project name in git, we need this for travis
     - role: ansible-role-degoss
-      tests: fixtures/fail.yml
+      tests:
+      - fixtures/fail.yml


### PR DESCRIPTION
Per https://github.com/ansible/ansible/issues/17136 , file glob has known issues in Ansible 2.2.0+ at the moment. Until this is resolved, I'm suggesting this PR to resolve this issue as an alternative to file glob.

Tests can be specified as either a single file or a path as an element in the tests array as well, as was previous behavior. The only change is that tests are now specified as an array vs a single string.