### PR TITLE
Attempted edge-case fix for dynamic goss source directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Variables affecting the runtime of Goss.
 <dl>
   <dt><code>goss_file</code></dt>
   <dd>A Goss test file to run on the target machine.</dd>
+  <dt><code>goss_source_dir</code></dt>
+  <dd>The directory, local to the playbook, to look for the Goss test file. Only affects goss_file</dd>
   <dt><code>goss_addtl_files</code></dt>
   <dd>Additional Goss test files to copy to the machine.</dd>
   <dt><code>goss_addtl_dirs</code></dt>
@@ -52,26 +54,36 @@ None.
 
 ### Single Test File
 
-Fetches the latest version of Goss and executes the `tests/goss.yml` file.
+Fetches the latest version of Goss and executes the `goss.yml` file locally.
 
 ```yaml
 ---
 - name: test
   hosts: all
   roles:
-    - { role: degoss, goss_file: tests/goss.yml }
+    - { role: degoss, goss_file: goss.yml }
+```
+
+Uses a custom directory
+
+```yaml
+---
+- name: test
+  hosts: all
+  roles:
+    - { role: degoss, goss_source_dir: tests/, goss_file: goss.yml }
 ```
 
 ### Pinned Version
 
-Downloads a specific version of Goss and executes the `tests/goss.yml` file.
+Downloads a specific version of Goss and executes the `goss.yml` file locally.
 
 ```yaml
 ---
 - name: test
   hosts: all
   roles:
-    - { role: degoss, goss_version: 0.2.5, goss_file: tests/goss.yml }
+    - { role: degoss, goss_version: 0.2.5, goss_file: goss.yml }
 ```
 
 ### Multiple Files and Directories
@@ -109,6 +121,19 @@ In this case, `distro` will be available to Goss at runtime at `{{.Env.distro}}`
 ## License
 
 MIT
+
+## Development
+In order to use the Makefile to test you will need two variables, `IMAGE_NAME` and `ROLE_NAME`.
+
+* `ROLE_NAME`
+  * This role, `degoss`
+* `IMAGE_NAME`
+  * one of:
+    * `IMAGE_NAME: "naftulikay/centos-vm:7"`
+    * `IMAGE_NAME: "naftulikay/xenial-vm:latest"`
+    * `IMAGE_NAME: "naftulikay/trusty-vm:latest"`
+* Example
+  * `IMAGE_NAME=naftulikay/xenial-vm:latest ROLE_NAME=degoss make test-clean`
 
 ---
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ degoss_changed_when: not (degoss_idempotent | bool)
 
 goss_version: latest
 goss_output_format: rspecish
+goss_source_dir:
 goss_file: goss.yml
 goss_addtl_files: []
 goss_addtl_dirs: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
 
 # deploy test files including the main and additional test files
 - name: deploy test files
-  copy: src={{ item }} dest={{ degoss_test_root }} mode=0644 directory_mode=0755 setype=user_tmp_t
+  copy: src="{{ goss_source_dir }}{{ item }}" dest={{ degoss_test_root }} mode=0644 directory_mode=0755 setype=user_tmp_t
   with_items: "{{ [goss_file] + goss_addtl_files + goss_addtl_dirs }}"
   changed_when: degoss_changed_when
 

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -30,6 +30,29 @@
           a: b
           c: d
 
+- name: pass-source-dir
+  hosts: all
+  become: true
+  any_errors_fatal: true
+  roles:
+    - role: degoss
+      degoss_clean: false
+      degoss_debug: true
+      goss_source_dir: tests/
+      goss_file: goss.yml
+      goss_addtl_dirs: [tests/goss]
+      goss_env_vars:
+        distro: "{{ ansible_distribution | lower }}"
+        should: "pass"
+        boolean: true
+        list:
+          - one
+          - two
+          - three
+        dict:
+          a: b
+          c: d
+
 - name: fail
   hosts: all
   become: true
@@ -40,6 +63,30 @@
       degoss_debug: true
       goss_file: goss.yml
       goss_addtl_dirs: [goss]
+      goss_env_vars:
+        distro: "{{ ansible_distribution | lower }}"
+        should: "fail"
+        boolean: true
+        list:
+          - one
+          - two
+          - three
+        dict:
+          a: b
+          c: d
+      when: fail is defined
+
+- name: fail-source-dir
+  hosts: all
+  become: true
+  any_errors_fatal: true
+  roles:
+    - role: degoss
+      degoss_clean: false
+      degoss_debug: true
+      goss_source_dir: tests/
+      goss_file: goss.yml
+      goss_addtl_dirs: [tests/goss]
       goss_env_vars:
         distro: "{{ ansible_distribution | lower }}"
         should: "fail"

--- a/tests/tests/goss.yml
+++ b/tests/tests/goss.yml
@@ -1,0 +1,7 @@
+---
+file:
+  '/dev':
+    exists: {{.Env.boolean}}
+
+gossfile:
+  'goss/should-{{.Env.should}}.yml': {}

--- a/tests/tests/goss/should-fail.yml
+++ b/tests/tests/goss/should-fail.yml
@@ -1,0 +1,14 @@
+---
+# check that the dev directory exists, it always should
+file:
+  '/dev':
+    exists: false
+
+package:
+{{ if eq .Env.distro "centos" }}
+  centos-release:
+    installed: false
+{{ else if eq .Env.distro "ubuntu" }}
+  ubuntu-keyring:
+    installed: false
+{{ end }}

--- a/tests/tests/goss/should-pass.yml
+++ b/tests/tests/goss/should-pass.yml
@@ -1,0 +1,13 @@
+---
+file:
+  '/tmp/nonexistent':
+    exists: true
+
+package:
+{{ if eq .Env.distro "centos" }}
+  centos-release:
+    installed: true
+{{ else if eq .Env.distro "ubuntu" }}
+  ubuntu-keyring:
+    installed: true
+{{ end }}


### PR DESCRIPTION
Adds: `goss_source_dir` which allows one to define a subdirectory to search for `goss_file` in, supporting playbooks run from a role's root.