### PR TITLE
Remove PyYAML Dependency

### DIFF
--- a/library/degoss.py
+++ b/library/degoss.py
@@ -15,7 +15,6 @@ import stat
 import subprocess
 import sys
 import tempfile
-import yaml
 
 
 if six.PY3:


### PR DESCRIPTION
It isn't required and was left in by mistake. On super minimal installations, PyYAML may not be installed.