### PR TITLE
Add option to set the working directory for degoss

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ degoss_clean_on_failure: true
 # Enable debug-level logging.
 degoss_debug: false
 # Sets directory where degoss will put test files on the remote host
-degoss_workdir: "/tmp"
+degoss_base_workdir: "/tmp"
 
 # A dictionary of variables to make available to Goss at runtime (e.g. {{.Vars.my_variable}})
 goss_variables: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ degoss_clean: true
 degoss_clean_on_failure: true
 # Enable debug-level logging.
 degoss_debug: false
+# Sets directory where degoss will put test files on the remote host
+degoss_workdir: "/tmp"
 
 # A dictionary of variables to make available to Goss at runtime (e.g. {{.Vars.my_variable}})
 goss_variables: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: create workdir
-  command: mktemp -d /tmp/degoss.XXXXXXXXXX
+  command: "mktemp -d {{ degoss_workdir }}/degoss.XXXXXXXXXX"
   register: workdir
   changed_when: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: create workdir
-  command: "mktemp -d {{ degoss_workdir }}/degoss.XXXXXXXXXX"
+  command: "mktemp -d {{ degoss_base_workdir }}/degoss.XXXXXXXXXX"
   register: workdir
   changed_when: false
 


### PR DESCRIPTION
If SELinux is enabled on the remote host, ansible cannot execute the workdir files in `/tmp`.

I have added an option to set the workdir that degoss puts the files in to mitigate the issue.