### PR TITLE
Bugfix/corbett bytestostring :: Python3 Support

### DIFF
--- a/library/degoss.py
+++ b/library/degoss.py
@@ -341,7 +341,7 @@ class Degoss(object):
         status, _, response = self.request(release_url)
 
         # write to a file
-        with open(self.executable, 'wb') as f:
+        with open(self.executable, 'w') as f:
             # buffered read at 8KiB chunks
             #chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
             chunk = response.read(BUFFER_SIZE)

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -350,12 +350,6 @@ class Degoss(object):
 
         self.logger.debug("Successfully installed the binary to %s", self.executable)
 
-    def decode_if_byte(self, chunk):
-        if isinstance(chunk, bytes):
-            return chunk.decode(encoding='cp437')
-        else:
-            return chunk
-
     def test(self):
         """Execute the test cases."""
         # deserialize the facts; note that when passing in a dictionary from Ansible as an argument, it is serialized

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -352,7 +352,8 @@ class Degoss(object):
             while chunk:
                 f.write(chunk)
                 chunk = response.read(BUFFER_SIZE)
-                chunk = chunk.decode(encoding='windows-1252')
+                if isinstance(chunk, bytes):
+                    chunk = chunk.decode(encoding='windows-1252')
 
             response.close()
 

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -334,26 +334,27 @@ class Degoss(object):
         """Install the Goss binary."""
         release_url = self.get_release_url()
 
-        
+
 
         self.logger.info("Installing the Goss binary from %s into %s", release_url, self.bin_dir)
 
         status, _, response = self.request(release_url)
 
-        chunk = response.read(BUFFER_SIZE)
-        if isinstance(chunk, bytes):
-            with open(self.executable, 'wb') as f:
-                while chunk:
-                    f.write(chunk)
-                    chunk = response.read(BUFFER_SIZE)
-                response.close()
-        else:
-            with open(self.executable, 'w') as f:
-                while chunk:
-                    f.write(chunk)
-                    chunk = response.read(BUFFER_SIZE)
+        # write to a file
+        with open(self.executable, 'w') as f:
+            # buffered read at 8KiB chunks
+            chunk = response.read(BUFFER_SIZE)
 
-                response.close()
+            # bytes to str for python3 file.write() support
+            if isinstance(chunk, bytes):
+                    chunk = chunk.decode(encoding='windows-1252')
+
+            while chunk:
+                f.write(chunk)
+                chunk = response.read(BUFFER_SIZE)
+                chunk = chunk.decode(encoding='windows-1252')
+
+            response.close()
 
         if self.os in ('linux', 'darwin'):
             # make it executable by the current user

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -343,6 +343,10 @@ class Degoss(object):
             # buffered read at 8KiB chunks
             chunk = response.read(BUFFER_SIZE)
 
+            # bytes to str for python3 file.write() support
+            if isinstance(chunk, bytes):
+                chunk = chunk.decode()
+
             while chunk:
                 f.write(chunk)
                 chunk = response.read(BUFFER_SIZE)

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -345,10 +345,6 @@ class Degoss(object):
             # buffered read at 8KiB chunks
             chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
 
-            # bytes to str for python3 file.write() support
-            if isinstance(chunk, bytes):
-                    chunk = chunk.decode(encoding='cp437')
-
             while chunk:
                 f.write(chunk)
                 chunk = self.decode_if_byte(response.read(BUFFER_SIZE))

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -334,7 +334,7 @@ class Degoss(object):
         """Install the Goss binary."""
         release_url = self.get_release_url()
 
-
+        self.logger.debug(f"URL: {release_url}")
 
         self.logger.info("Installing the Goss binary from %s into %s", release_url, self.bin_dir)
 

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -342,14 +342,16 @@ class Degoss(object):
 
         # write to a file
         with open(self.executable, 'w') as f:
+
+            shutil.copyfileobj(response.read(), f)
             # buffered read at 8KiB chunks
             #chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
-            chunk = response.read(BUFFER_SIZE)
+            #chunk = response.read(BUFFER_SIZE)
 
-            while chunk:
-                f.write(chunk)
+            #while chunk:
+                #f.write(chunk)
                 #chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
-                chunk = response.read(BUFFER_SIZE)
+                #chunk = response.read(BUFFER_SIZE)
 
             response.close()
 

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -343,17 +343,15 @@ class Degoss(object):
         # write to a file
         with open(self.executable, 'w') as f:
             # buffered read at 8KiB chunks
-            chunk = response.read(BUFFER_SIZE)
+            chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
 
             # bytes to str for python3 file.write() support
             if isinstance(chunk, bytes):
-                    chunk = chunk.decode(encoding='windows-1252')
+                    chunk = chunk.decode(encoding='cp437')
 
             while chunk:
                 f.write(chunk)
-                chunk = response.read(BUFFER_SIZE)
-                if isinstance(chunk, bytes):
-                    chunk = chunk.decode(encoding='windows-1252')
+                chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
 
             response.close()
 
@@ -362,6 +360,12 @@ class Degoss(object):
             os.chmod(self.executable, 0o0700)
 
         self.logger.debug("Successfully installed the binary to %s", self.executable)
+
+    def decode_if_byte(self, chunk):
+        if isinstance(chunk, bytes):
+            return chunk.decode(encoding='cp437')
+        else:
+            return chunk
 
     def test(self):
         """Execute the test cases."""

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -341,13 +341,15 @@ class Degoss(object):
         status, _, response = self.request(release_url)
 
         # write to a file
-        with open(self.executable, 'w') as f:
+        with open(self.executable, 'wb') as f:
             # buffered read at 8KiB chunks
-            chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
+            #chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
+            chunk = response.read(BUFFER_SIZE)
 
             while chunk:
                 f.write(chunk)
-                chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
+                #chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
+                chunk = response.read(BUFFER_SIZE)
 
             response.close()
 

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -399,7 +399,7 @@ class Degoss(object):
             self.test_dir, dict(os.environ))
 
         p = subprocess.Popen(cli_arguments, cwd=self.test_dir, env=dict(os.environ), stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT, stdin=subprocess.PIPE)
+            stderr=subprocess.STDOUT, stdin=subprocess.PIPE, encoding='utf8')
 
         stdout, _ = p.communicate(input=json.dumps(goss_variables))
 

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -341,9 +341,9 @@ class Degoss(object):
         status, _, response = self.request(release_url)
 
         # write to a file
-        with open(self.executable, 'w') as f:
+        with open(self.executable, 'wb') as f:
 
-            shutil.copyfileobj(response.read(), f)
+            shutil.copyfileobj(response, f)
             # buffered read at 8KiB chunks
             #chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
             #chunk = response.read(BUFFER_SIZE)

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -334,8 +334,6 @@ class Degoss(object):
         """Install the Goss binary."""
         release_url = self.get_release_url()
 
-        self.logger.debug(f"URL: {release_url}")
-
         self.logger.info("Installing the Goss binary from %s into %s", release_url, self.bin_dir)
 
         status, _, response = self.request(release_url)
@@ -344,15 +342,6 @@ class Degoss(object):
         with open(self.executable, 'wb') as f:
 
             shutil.copyfileobj(response, f)
-            # buffered read at 8KiB chunks
-            #chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
-            #chunk = response.read(BUFFER_SIZE)
-
-            #while chunk:
-                #f.write(chunk)
-                #chunk = self.decode_if_byte(response.read(BUFFER_SIZE))
-                #chunk = response.read(BUFFER_SIZE)
-
             response.close()
 
         if self.os in ('linux', 'darwin'):

--- a/library/degoss.py
+++ b/library/degoss.py
@@ -334,24 +334,26 @@ class Degoss(object):
         """Install the Goss binary."""
         release_url = self.get_release_url()
 
+        
+
         self.logger.info("Installing the Goss binary from %s into %s", release_url, self.bin_dir)
 
         status, _, response = self.request(release_url)
 
-        # write to a file
-        with open(self.executable, 'w') as f:
-            # buffered read at 8KiB chunks
-            chunk = response.read(BUFFER_SIZE)
+        chunk = response.read(BUFFER_SIZE)
+        if isinstance(chunk, bytes):
+            with open(self.executable, 'wb') as f:
+                while chunk:
+                    f.write(chunk)
+                    chunk = response.read(BUFFER_SIZE)
+                response.close()
+        else:
+            with open(self.executable, 'w') as f:
+                while chunk:
+                    f.write(chunk)
+                    chunk = response.read(BUFFER_SIZE)
 
-            # bytes to str for python3 file.write() support
-            if isinstance(chunk, bytes):
-                chunk = chunk.decode()
-
-            while chunk:
-                f.write(chunk)
-                chunk = response.read(BUFFER_SIZE)
-
-            response.close()
+                response.close()
 
         if self.os in ('linux', 'darwin'):
             # make it executable by the current user


### PR DESCRIPTION
Sorry for the commit spam - squash on merge to clean that up.

* Python3 support

Tested on `3.8.5`

Python3 introduces more aggression around the difference between str and bytes, apparent in a few operations degoss.py was performing

----

* Update binary download to just use shutil - it is chunking and buffering in the background anyways and response is a file-like object (response.read() becomes bytes in py3 and it was having encoding issues)
* Update subprocess to use utf8 encoding (IO becomes bytes in py3)

---- Should fix https://github.com/naftulikay/ansible-role-degoss/issues/47